### PR TITLE
添加局域网 WOL 唤醒插件 (astrbot_plugin_wol)

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -49,4 +49,9 @@
         "author": "scwunai",
         "repo": "https://github.com/scwunai/Astrbot_Plugin_Dice_scwunai"
     }
+    "astrbot_plugin_wol": {
+        "desc": "局域网 WOL 唤醒插件，/wolhelp 查看帮助",
+        "author": "Camreishi",
+        "repo": "https://github.com/Camreishi/astrbot_plugin_wol"
+    }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -48,7 +48,7 @@
         "desc": "一个骰子插件，支持设置面数和检定阈值，输入/dicehelp获取帮助",
         "author": "scwunai",
         "repo": "https://github.com/scwunai/Astrbot_Plugin_Dice_scwunai"
-    }
+    },
     "astrbot_plugin_wol": {
         "desc": "局域网 WOL 唤醒插件，/wolhelp 查看帮助",
         "author": "Camreishi",


### PR DESCRIPTION
添加astrbot_plugin_wol 插件到AstrBot Plugin 插件集合站

插件名称：astrbot_plugin_wol
插件描述：局域网 WOL 唤醒插件，支持通过设备名称或 MAC 地址唤醒设备。
插件帮助：使用`/wolhelp`查看帮助
插件仓库：https://github.com/Camreishi/astrbot_plugin_wol