### PR TITLE
ban_plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,26 @@
-# AstrBot_Plugins_Collection
+# AstrBot 禁用插件
 
-AstrBot Plugin 插件集合站，用于在 AstrBot 仪表盘-插件页中作为插件市场显示。
+这是一个用于 AstrBot 的禁用插件，允许管理员通过指令禁用或解除指定 QQ 用户的机器人使用权限，ban-help查看详情
 
-## 提交插件
+## 功能
 
-1. Fork 本仓库
-2. 修改 `plugins.json` 文件，添加你的插件信息
-   1. key 为你的插件名
-   2. value 为插件信息，必须包括 `repo`, `desc`, `author` 等字段。
-   3. 例子：
-      ```json
-      "astrbot_plugin_essential": {
-        "desc": "随机动漫图片、以图搜番、Minecraft服务器、一言、今天吃什么、群早晚安记录、EPIC喜加一。帮助：https://github.com/Soulter/astrbot_plugin_essential",
-        "author": "Soulter",
-        "repo": "https://github.com/Soulter/astrbot_plugin_essential"
-      }
-      ```
+- **ban <QQ号>**：在当前群聊中禁用指定 QQ 用户，禁用后该用户在本群内发送的消息将不被机器人处理。
+- **ban-all <QQ号>**：全局禁用指定 QQ 用户，禁用后该用户在所有场景（群聊和私聊）发送的消息均不被机器人处理。
+- **pass <QQ号>**：解除当前群聊中对指定 QQ 用户的禁用。
+- **pass-all <QQ号>**：解除全局对指定 QQ 用户的禁用。
+
+## 使用方法
+
+1. 将本插件仓库克隆或下载后，放入 AstrBot 项目的 `data/plugins/` 目录下，确保目录名称为 `astrbot_plugin_ban`。
+2. 确认插件文件完整（包括 `main.py`、`metadata.yaml`、`README.md` 以及可选的配置文件）。
+3. 重启 AstrBot，插件会自动加载，并在管理面板的插件列表中显示为已安装插件。
+4. 使用管理员账号在群聊中发送指令，即可控制用户的禁用状态。
+
+## 配置
+
+目前本插件暂无额外配置项。如有需要，可通过添加 `_conf_schema.json` 文件扩展配置。
+
+## 开发
+
+参考 [AstrBot 插件开发文档](https://astrbot.soulter.top/dev/plugin.html) 了解更多插件开发和打包上传的细节。
+

--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -1,0 +1,13 @@
+{
+    "ban_config": {
+        "description": "禁用插件配置",
+        "type": "object",
+        "items": {
+            "enable": {
+                "description": "是否启用禁用功能",
+                "type": "bool",
+                "default": true
+            }
+        }
+    }
+}

--- a/main.py
+++ b/main.py
@@ -1,0 +1,221 @@
+from astrbot.api.event import filter, AstrMessageEvent
+from astrbot.api.star import Context, Star, register
+from astrbot.api import sp
+from astrbot.api.message_components import At
+
+@register("ban_plugin", "水蜜桃", "用于禁用指定 QQ 用户在群聊或全局范围内使用机器人功能的插件", "1.0.0")
+class BanPlugin(Star):
+    def __init__(self, context: Context, config: dict):
+        super().__init__(context)
+        # 从插件配置中获取是否启用禁用功能，默认为启用
+        self.enable = config.get('enable', True)
+        # 持久化存储，使用 sp 接口加载数据（数据存储为 list，转换为 set 便于处理）
+        self.global_ban = set(sp.get('ban_plugin_global_ban', []))
+        group_ban_raw = sp.get('ban_plugin_group_ban', {})
+        self.group_ban = {gid: set(lst) for gid, lst in group_ban_raw.items()}
+        group_allow_raw = sp.get('ban_plugin_group_allow', {})
+        self.group_allow = {gid: set(lst) for gid, lst in group_allow_raw.items()}
+
+    def persist(self):
+        """将当前禁用数据持久化保存"""
+        sp.put('ban_plugin_global_ban', list(self.global_ban))
+        sp.put('ban_plugin_group_ban', {gid: list(s) for gid, s in self.group_ban.items()})
+        sp.put('ban_plugin_group_allow', {gid: list(s) for gid, s in self.group_allow.items()})
+        sp.put('ban_plugin_enable', self.enable)
+
+    def is_banned(self, event: AstrMessageEvent):
+        """判断消息发送者是否被禁用。对于群聊场景：
+           如果该群存在局部例外，则即使在全局禁用中也允许使用，
+           否则全局禁用或群禁用均视为被禁用。"""
+        qq = str(event.get_sender_id())
+        group_id = event.message_obj.group_id if hasattr(event.message_obj, "group_id") else ""
+        if group_id and group_id in self.group_allow and qq in self.group_allow[group_id]:
+            return False
+        if qq in self.global_ban:
+            return True
+        if group_id and group_id in self.group_ban and qq in self.group_ban[group_id]:
+            return True
+        return False
+
+    @filter.event_message_type(filter.EventMessageType.ALL)
+    async def filter_banned_users(self, event: AstrMessageEvent):
+        """
+        全局事件过滤器：
+        如果禁用功能启用且发送者被禁用，则停止事件传播，机器人不再响应该用户的消息。
+        """
+        if not self.enable:
+            return
+        if self.is_banned(event):
+            event.stop_event()
+            return
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("ban")
+    async def ban_user(self, event: AstrMessageEvent):
+        """
+        在当前群聊中禁用指定 QQ 用户的使用权限。
+        格式：/ban @用户...
+        支持同时禁用多个用户，且忽略对自己的 @。
+        """
+        sender_id = str(event.get_sender_id())
+        chain = event.message_obj.message
+        ats = []
+        for comp in chain:
+            if isinstance(comp, At):
+                qq = str(comp.qq)
+                if qq == sender_id:
+                    # 忽略管理员对自己的 @
+                    continue
+                ats.append(qq)
+        if not ats:
+            yield event.plain_result("请在 /ban 后 @ 一个或多个用户。")
+            return
+
+        group_id = event.message_obj.group_id if hasattr(event.message_obj, "group_id") else None
+        if not group_id:
+            yield event.plain_result("该指令仅限群聊中使用。")
+            return
+
+        for qq in ats:
+            # 若当前群存在局部例外，则移除局部例外记录
+            if group_id in self.group_allow:
+                self.group_allow[group_id].discard(qq)
+            self.group_ban.setdefault(group_id, set()).add(qq)
+        self.persist()
+        yield event.plain_result(f"已在本群禁用 QQ {', '.join(ats)} 的使用权限。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("ban-all")
+    async def ban_user_all(self, event: AstrMessageEvent):
+        """
+        全局禁用指定 QQ 用户的使用权限。
+        格式：/ban-all @用户...
+        支持同时禁用多个用户。
+        """
+        chain = event.message_obj.message
+        ats = [str(comp.qq) for comp in chain if isinstance(comp, At)]
+        if not ats:
+            yield event.plain_result("请在 /ban-all 后 @ 一个或多个用户。")
+            return
+
+        for qq in ats:
+            self.global_ban.add(qq)
+        self.persist()
+        yield event.plain_result(f"已全局禁用 QQ {', '.join(ats)} 的使用权限。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("pass")
+    async def unban_user(self, event: AstrMessageEvent):
+        """
+        解除当前群聊中对指定 QQ 用户的禁用。
+        格式：/pass @用户...
+        解除禁用后，即使该用户处于全局禁用中，在本群也可以使用机器人，
+        但在其他场景仍受全局禁用限制。
+        """
+        chain = event.message_obj.message
+        ats = [str(comp.qq) for comp in chain if isinstance(comp, At)]
+        if not ats:
+            yield event.plain_result("请在 /pass 后 @ 一个或多个用户。")
+            return
+
+        group_id = event.message_obj.group_id if hasattr(event.message_obj, "group_id") else None
+        if not group_id:
+            yield event.plain_result("该指令仅限群聊中使用。")
+            return
+
+        for qq in ats:
+            if group_id in self.group_ban and qq in self.group_ban[group_id]:
+                self.group_ban[group_id].remove(qq)
+            self.group_allow.setdefault(group_id, set()).add(qq)
+        self.persist()
+        yield event.plain_result(f"已解除本群中对 QQ {', '.join(ats)} 的禁用。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("pass-all")
+    async def unban_user_all(self, event: AstrMessageEvent):
+        """
+        解除对指定 QQ 用户的所有禁用（全局及所有群聊）。
+        格式：/pass-all @用户...
+        支持同时解除多个用户的所有禁用。
+        执行后，将彻底移除该用户在全局、所有群聊中因禁用产生的限制。
+        """
+        chain = event.message_obj.message
+        ats = [str(comp.qq) for comp in chain if isinstance(comp, At)]
+        if not ats:
+            yield event.plain_result("请在 /pass-all 后 @ 一个或多个用户。")
+            return
+
+        for qq in ats:
+            # 解除全局禁用
+            self.global_ban.discard(qq)
+            # 遍历所有群聊，解除该用户的群禁用记录
+            for gid in list(self.group_ban.keys()):
+                self.group_ban[gid].discard(qq)
+                if not self.group_ban[gid]:
+                    del self.group_ban[gid]
+            # 同时移除所有群聊中的局部例外记录（恢复到未设置状态）
+            for gid in list(self.group_allow.keys()):
+                self.group_allow[gid].discard(qq)
+                if not self.group_allow[gid]:
+                    del self.group_allow[gid]
+        self.persist()
+        yield event.plain_result(f"已解除全局及所有群聊中对 QQ {', '.join(ats)} 的禁用。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("ban_enable")
+    async def ban_enable(self, event: AstrMessageEvent):
+        """
+        启用禁用功能。
+        格式：/ban_enable
+        """
+        self.enable = True
+        self.persist()
+        yield event.plain_result("已临时启用禁用功能，重启后失效。永久启用请在插件配置中修改。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("ban_disable")
+    async def ban_disable(self, event: AstrMessageEvent):
+        """
+        禁用禁用功能。
+        格式：/ban_disable
+        """
+        self.enable = False
+        self.persist()
+        yield event.plain_result("已禁用禁用功能，重启后失效。永久禁用请在插件配置中修改。")
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("banlist")
+    async def list_banned_users(self, event: AstrMessageEvent):
+        """
+        列出当前禁用的用户。
+        格式：/banlist
+        若在群聊中，会显示本群禁用的用户及全局禁用的用户。
+        """
+        group_id = event.message_obj.group_id if hasattr(event.message_obj, "group_id") else None
+        ret = ""
+        if group_id:
+            group_banned = self.group_ban.get(group_id, set())
+            ret += f"本群禁用的用户: {', '.join(group_banned) if group_banned else '无'}\n"
+        ret += f"全局禁用的用户: {', '.join(self.global_ban) if self.global_ban else '无'}"
+        yield event.plain_result(ret)
+
+    @filter.permission_type(filter.PermissionType.ADMIN)
+    @filter.command("ban-help")
+    async def ban_help(self, event: AstrMessageEvent):
+        """
+        管理员专用命令：显示该插件所有命令列表及功能说明。
+        格式：/ban-help
+        """
+        help_text = (
+            "【ban_plugin 插件命令帮助】\n"
+            "1. /ban @用户...：在当前群聊中禁用指定 QQ 用户（支持同时禁用多个用户，忽略对自己的 @）。\n"
+            "2. /ban-all @用户...：全局禁用指定 QQ 用户（支持同时禁用多个用户）。\n"
+            "3. /pass @用户...：解除当前群聊中对指定 QQ 用户的禁用（即使其全局禁用，仍可在本群使用）。\n"
+            "4. /pass-all @用户...：解除全局及所有群聊中对指定 QQ 用户的禁用。\n"
+            "5. /ban_enable：启用禁用功能。\n"
+            "6. /ban_disable：禁用禁用功能。\n"
+            "7. /banlist：列出当前禁用的用户（包括本群及全局）。\n"
+            "8. /ban-help：显示此帮助信息。"
+        )
+        yield event.plain_result(help_text)
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,0 +1,5 @@
+name: "astrbot_plugin_ban"
+version: "1.0.0"
+author: "水蜜桃"
+description: "用于禁用指定 QQ 用户在群聊或全局范围内使用机器人功能的插件。管理员可通过指令对用户进行禁用或解除禁用，ban-help查看详情"
+  

--- a/plugins.json
+++ b/plugins.json
@@ -1,7 +1,7 @@
 {
     "astrbot_plugin_blacklist": {
         "desc": "黑名单插件，禁止用户和 AstrBot 交互，适用于 aiocqhttp, gewechat",
-        "author": "大核桃",
+        "author": "水蜜桃",
         "repo": "https://github.com/AstrBot-Devs/astrbot_plugin_blacklist"
     },
     "mccloud_zhipu_img": {


### PR DESCRIPTION
1.修改了使用逻辑，同步修改为直接@用户，增加同时禁用多个用户
2.修复了禁用逻辑，当一个用户已经被ban时，pass-all无法解除当前群聊被禁用的问题
3.同步增加禁用列表查询功能
4.数据持久化
5.忽略了管理员@自身的误操作