### PR TITLE
一个基于 OpenWeatherMap v2.5 API 的天气查询插件

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -93,5 +93,10 @@
         "desc": "获取当前系统状态",
         "author": "mika",
         "repo": "https://github.com/AstrBot-Devs/astrbot_plugin_sysinfo"
+    },
+    "astrbot_plugin_weather": {
+        "desc": "一个基于 OpenWeatherMap v2.5 API 的天气查询插件",
+        "author": "w33d",
+        "repo": "https://github.com/Last-emo-boy/astrbot_plugin_weather"
     }
 }


### PR DESCRIPTION
# Weather Plugin

基于 **OpenWeatherMap v2.5** 的天气查询插件，为 [AstrBot](https://github.com/Soulter/AstrBot) 提供 `/weather` 指令，支持查询当前天气、未来 3 天预报等功能。

## 功能

1. **当前天气**：输入 `/weather current <城市>` 即可查询该城市的实时天气信息。
2. **未来预报**：输入 `/weather forecast <城市>` 可查看未来 3 天的天气预报。
3. **自定义配置**：通过管理面板或配置文件修改 API Key、默认城市等。
4. **可选 LLM Function-Calling**：在开启 function-calling 的情况下，LLM 可自动调用插件提供的天气查询工具函数。

## 安装与配置

1. 将插件文件夹（包含 `main.py`, `_conf_schema.json`, `plugin.yaml` 等）放入 AstrBot 的插件目录。
2. 重启 AstrBot，进入管理面板找到本插件，在“配置”中填写你的 **OpenWeatherMap** API Key（免费版也可使用，但功能有限）。
3. 如需修改默认城市或其他选项，可在管理面板的插件配置处或在 `config` 文件中进行更改。

## 使用示例

- **查询当前天气：**
  ```
  /weather current 上海
  ```
  插件会返回一个图文卡片，展示温度、湿度、风速等信息。

- **查询未来 3 天预报：**
  ```
  /weather forecast 上海
  ```
  插件会返回一个包含后 3 天天气情况的图片。

- **查看插件帮助：**
  ```
  /weather help
  ```