### PR TITLE
feat: add astrbot_plugin_image2_gen

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -11811,5 +11811,17 @@
     "desc": "过滤消息段中的think",
     "repo": "https://github.com/zgojin/astrbot_plugin_thinkTags",
     "category": "utilities"
+  },
+  "astrbot_plugin_image2_gen": {
+    "display_name": "Image-2 生图",
+    "desc": "调用 OpenAI 兼容 Images API（默认 gpt-image-2）生成或编辑图片并发送，支持 /image2 指令与 LLM 工具后台派发。",
+    "author": "SGSxingchen",
+    "repo": "https://github.com/SGSxingchen/astrbot_plugin_image2_gen",
+    "tags": [
+      "image",
+      "image-generation",
+      "gpt-image-2",
+      "openai"
+    ]
   }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -11822,6 +11822,7 @@
       "image-generation",
       "gpt-image-2",
       "openai"
-    ]
+    ],
+    "category": "ai_tools"
   }
 }


### PR DESCRIPTION
## 新增插件

- **名称**: astrbot_plugin_image2_gen
- **作者**: SGSxingchen
- **仓库**: https://github.com/SGSxingchen/astrbot_plugin_image2_gen
- **License**: MIT
- **AstrBot 版本**: 已在 AstrBot 主线版本测试通过

## 功能简介

调用 OpenAI 兼容 Images API（默认模型 `gpt-image-2`）生成或编辑图片并发送：

- `/image2 <prompt>` 文本生图，调用 `{base_url}/images/generations`
- 消息附图或引用图时改图，调用 `{base_url}/images/edits`
- LLM 工具 `image2_generate(prompt, image_url="")`，后台派发任务，完成后自动发送图片
- 配置项可自定义 Base URL、模型名、超时和各类提示语

## 检查项

- [x] 已在仓库根目录提供 `metadata.yaml`、`_conf_schema.json`、`README.md`、`requirements.txt`、`LICENSE`
- [x] 仅修改 `plugins.json`，新增一条目，未修改其他记录
- [x] 仓库为公开 GitHub 仓库，可正常 clone

如需调整 `tags` / `desc` / `display_name`，请直接评论指出，我会立刻修改。

## Summary by Sourcery

New Features:
- Add the astrbot_plugin_image2_gen entry to plugins.json to enable OpenAI-compatible image generation and editing via the Images API.