### PR TITLE
Add plugin: astrbot_plugin_tts_speak - TTS语音合成插件

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -10,7 +10,9 @@
       "语音合成",
       "speak"
     ],
-    "social_link": "https://github.com/leemwood"
+    "social_link": "https://github.com/leemwood",
+    "category": "ai_tools",
+    "version": "1.0.0"
   },
   "astrbot_plugin_kimi_web_search": {
     "display_name": "Kimi 联网搜索（WebSearch）",

--- a/plugins.json
+++ b/plugins.json
@@ -1,4 +1,17 @@
 {
+  "astrbot_plugin_tts_speak": {
+    "display_name": "TTS Speak 语音合成",
+    "desc": "让LLM能够自主调用TTS合成语音并发送语音消息的插件。注册了 tts_speak 工具函数，使AI可以主动使用语音回复。",
+    "author": "小炎 & 柠枺",
+    "repo": "https://github.com/leemwood/astrbot_plugin_tts_speak",
+    "tags": [
+      "tts",
+      "语音",
+      "语音合成",
+      "speak"
+    ],
+    "social_link": "https://github.com/leemwood"
+  },
   "astrbot_plugin_kimi_web_search": {
     "display_name": "Kimi 联网搜索（WebSearch）",
     "desc": "使用 Kimi coding plan 的 /coding/v1/search 和 /coding/v1/fetch 为 AstrBot Agent 提供互联网搜索和网页读取能力",


### PR DESCRIPTION
## 插件介绍
让LLM能够自主调用TTS合成语音并发送语音消息的插件。

## 功能特性
- 注册 \+tts_speak\+ 工具函数，让LLM能主动调用TTS
- 自动检测并使用 AstrBot 配置的 TTS 提供商
- 合成语音后通过 Record 组件发送语音消息

## 作者
小炎 & 柠枺

## 仓库地址
https://github.com/leemwood/astrbot_plugin_tts_speak

## 版本
v1.0.0

## Summary by Sourcery

New Features:
- Introduce the astrbot_plugin_tts_speak plugin to allow LLMs to invoke text-to-speech and send voice messages via the Record component.