### PR TITLE
fix: Notion Bridge display_name 移除🔗，版本同步至 v2.0.1

### DIFF
--- a/plugin_cache_original.json
+++ b/plugin_cache_original.json
@@ -172,7 +172,7 @@
     "logo": "https://raw.githubusercontent.com/Volundio/astrbot_plugin_openlist_bot/main/logo.png"
   },
   "astrbot-plugin-notion-bridge": {
-    "display_name": "Notion Bridge 🔗",
+    "display_name": "Notion Bridge",
     "desc": "桥接 Notion 与 AstrBot 的双向文档管理工具。支持递归读取、关键词搜索、知识库同步、LLM 查询，以及完整的文档增删改查（页面/块/数据库/用户/评论）。内置 Notion API 3 req/s 速率限制器，可靠管理大量文档。",
     "short_desc": "双向控制 Notion：读取、写入、搜索、管理一站式",
     "version": "2.0.1",

--- a/plugins.json
+++ b/plugins.json
@@ -113,10 +113,10 @@
     ]
   },
   "astrbot-plugin-notion-bridge": {
-    "display_name": "Notion Bridge 🔗",
+    "display_name": "Notion Bridge",
     "desc": "桥接 Notion 与 AstrBot 的双向文档管理工具。支持递归读取、关键词搜索、知识库同步、LLM 查询，以及完整的文档增删改查（页面/块/数据库/用户/评论）。内置 Notion API 3 req/s 速率限制器，可靠管理大量文档。",
     "short_desc": "双向控制 Notion：读取、写入、搜索、管理一站式",
-    "version": "v2.0.0",
+    "version": "v2.0.1",
     "author": "Masumeiki",
     "repo": "https://github.com/Masumeiki/astrbot_plugin_notion_bridge",
     "tags": [
@@ -126,7 +126,8 @@
       "双向同步",
       "API"
     ],
-    "social_link": ""
+    "social_link": "",
+    "updated_at": "2026-06-07T03:35:17Z"
   },
   "astrbot_plugin_dynamic_subagent": {
     "display_name": "dynamic_subagent",


### PR DESCRIPTION
## 修改内容

修复 Notion Bridge 在插件市场的显示问题：

1. **plugin_cache_original.json** — `display_name` 从 `"Notion Bridge 🔗"` 改为 `"Notion Bridge"`，移除多余的🔗
2. **plugins.json** — `display_name` 同修改，版本号从 `v2.0.0` 同步更新至 `v2.0.1`

## 原因

插件的 `metadata.yaml` 中 `display_name` 已经是 `Notion Bridge`，但插件市场缓存数据中仍保留了旧名称中的🔗。同时版本号也未同步到最新发布版本。

## Summary by Sourcery

Align Notion Bridge plugin marketplace metadata with the latest release.

Bug Fixes:
- Correct the Notion Bridge display_name in cached plugin metadata to remove the trailing emoji and match the canonical name.
- Synchronize the Notion Bridge plugin version in marketplace metadata from v2.0.0 to v2.0.1.