### PR TITLE
fix: balance plugin cache GitHub tokens

### DIFF
--- a/.github/workflows/transform-plugin-data.yml
+++ b/.github/workflows/transform-plugin-data.yml
@@ -25,3 +25,4 @@ jobs:
       run: python3 scripts/transform_plugin_data/run.py
       env:
         PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
+        PAT_TOKEN_2: ${{ secrets.PAT_TOKEN_2 }}

--- a/scripts/transform_plugin_data/run.py
+++ b/scripts/transform_plugin_data/run.py
@@ -13,6 +13,7 @@ import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
+from threading import Lock
 from typing import Any, Dict, Optional, Tuple
 
 
@@ -24,9 +25,26 @@ MAX_RETRIES = int(os.getenv("MAX_RETRIES", "5"))
 BASE_DELAY = float(os.getenv("BASE_DELAY", "2"))
 MAX_DELAY = float(os.getenv("MAX_DELAY", "30"))
 MAX_WORKERS = int(os.getenv("MAX_WORKERS", "12"))
+RATE_LIMIT_WAIT_PADDING = float(os.getenv("RATE_LIMIT_WAIT_PADDING", "5"))
+RATE_LIMIT_WAIT_CAP = float(os.getenv("RATE_LIMIT_WAIT_CAP", "900"))
 
-PAT_TOKEN = os.getenv("PAT_TOKEN", "").strip()
 GITHUB_URL = "https://raw.githubusercontent.com/AstrBotDevs/AstrBot_Plugins_Collection/main/plugins.json"
+
+GITHUB_TOKENS = []
+_TOKEN_LOCK = Lock()
+_TOKEN_INDEX = 0
+
+
+def load_github_tokens() -> list[str]:
+    tokens: list[str] = []
+    for env_name in ("PAT_TOKEN", "PAT_TOKEN_2"):
+        token = os.getenv(env_name, "").strip()
+        if token and token not in tokens:
+            tokens.append(token)
+    return tokens
+
+
+GITHUB_TOKENS = load_github_tokens()
 
 
 def run_cmd(args: list[str], check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -50,34 +68,126 @@ def save_json(path: str, data: Any, pretty: bool = False) -> None:
             json.dump(data, f, ensure_ascii=False, separators=(",", ":"))
 
 
-def get_headers(accept: str = "application/vnd.github+json") -> Dict[str, str]:
+def select_github_token() -> str:
+    global _TOKEN_INDEX
+    if not GITHUB_TOKENS:
+        return ""
+    with _TOKEN_LOCK:
+        token = GITHUB_TOKENS[_TOKEN_INDEX % len(GITHUB_TOKENS)]
+        _TOKEN_INDEX += 1
+    return token
+
+
+def get_headers(
+    accept: str = "application/vnd.github+json",
+    token: Optional[str] = None,
+) -> Dict[str, str]:
     headers = {
         "Accept": accept,
         "User-Agent": "GitHub-Action-Plugin-Transformer",
     }
-    if PAT_TOKEN:
-        headers["Authorization"] = f"token {PAT_TOKEN}"
+    if token:
+        headers["Authorization"] = f"token {token}"
     return headers
 
 
-def http_get_json(url: str, timeout: int = 20) -> Tuple[Optional[Dict[str, Any]], int]:
-    req = urllib.request.Request(url, headers=get_headers())
+def parse_positive_float(value: Optional[str]) -> Optional[float]:
+    if not value:
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def calculate_retry_delay(
+    attempt: int,
+    status: int,
+    headers: Any,
+) -> float:
+    retry_after = parse_positive_float(headers.get("Retry-After"))
+    if retry_after is not None:
+        return min(retry_after, RATE_LIMIT_WAIT_CAP)
+
+    remaining = headers.get("X-RateLimit-Remaining")
+    reset_at = parse_positive_float(headers.get("X-RateLimit-Reset"))
+    if status in (403, 429) and remaining == "0" and reset_at is not None:
+        if status == 403 and len(GITHUB_TOKENS) > 1 and attempt < len(GITHUB_TOKENS):
+            return 0
+        wait_seconds = reset_at - time.time() + RATE_LIMIT_WAIT_PADDING
+        return min(max(wait_seconds, BASE_DELAY), RATE_LIMIT_WAIT_CAP)
+
+    delay = min(BASE_DELAY * (2 ** (attempt - 1)), MAX_DELAY)
+    return delay + random.uniform(0, delay * 0.5)
+
+
+def is_rate_limited(payload: Optional[Dict[str, Any]], status: int, headers: Any) -> bool:
+    if status == 429:
+        return True
+    if status != 403:
+        return False
+    if headers.get("X-RateLimit-Remaining") == "0":
+        return True
+    if isinstance(payload, dict):
+        message = str(payload.get("message", "")).lower()
+        return "rate limit" in message or "secondary rate limit" in message
+    return False
+
+
+def should_retry_json_request(
+    payload: Optional[Dict[str, Any]],
+    status: int,
+    headers: Any,
+) -> bool:
+    return status == -1 or status in (500, 502, 503, 504) or is_rate_limited(payload, status, headers)
+
+
+def http_get_json(url: str, timeout: int = 20) -> Tuple[Optional[Dict[str, Any]], int, Any]:
+    token = select_github_token()
+    req = urllib.request.Request(url, headers=get_headers(token=token))
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
             status = resp.getcode()
             body = resp.read().decode("utf-8", errors="replace")
             if not body:
-                return {}, status
-            return json.loads(body), status
+                return {}, status, resp.headers
+            return json.loads(body), status, resp.headers
     except urllib.error.HTTPError as e:
         status = e.code
         try:
             body = e.read().decode("utf-8", errors="replace")
-            return (json.loads(body) if body else {}), status
+            return (json.loads(body) if body else {}), status, e.headers
         except Exception:
-            return {}, status
+            return {}, status, e.headers
     except Exception:
-        return None, -1
+        return None, -1, {}
+
+
+def http_get_json_with_retries(
+    url: str,
+    *,
+    timeout: int = 20,
+    context: str,
+) -> Tuple[Optional[Dict[str, Any]], int, Any]:
+    payload: Optional[Dict[str, Any]] = None
+    status = -1
+    headers: Any = {}
+    for attempt in range(1, MAX_RETRIES + 1):
+        payload, status, headers = http_get_json(url, timeout=timeout)
+        if not should_retry_json_request(payload, status, headers):
+            return payload, status, headers
+
+        if attempt >= MAX_RETRIES:
+            break
+
+        delay = calculate_retry_delay(attempt, status, headers)
+        print(
+            f"    {context} 请求失败 HTTP {status}，等待 {delay:.1f}s 后重试 ({attempt}/{MAX_RETRIES})",
+            flush=True,
+        )
+        time.sleep(delay)
+    return payload, status, headers
 
 
 def configure_git() -> None:
@@ -90,7 +200,7 @@ def fetch_original_plugin_data() -> Tuple[bool, Dict[str, Any]]:
     print("开始获取原始插件数据...", flush=True)
     req = urllib.request.Request(
         GITHUB_URL,
-        headers=get_headers(accept="application/json"),
+        headers=get_headers(accept="application/json", token=select_github_token()),
     )
     try:
         with urllib.request.urlopen(req, timeout=30) as resp:
@@ -167,32 +277,21 @@ def build_cache_by_repo(cache_data: Dict[str, Any]) -> Dict[str, Dict[str, Any]]
 
 def fetch_repo(owner: str, repo: str) -> Tuple[Optional[Dict[str, Any]], str]:
     url = f"https://api.github.com/repos/{owner}/{repo}"
-    for attempt in range(1, MAX_RETRIES + 1):
-        if attempt > 1:
-            delay = min(BASE_DELAY * (2 ** (attempt - 2)), MAX_DELAY)
-            delay += random.uniform(0, delay * 0.5)
-            print(f"    第 {attempt} 次尝试 (延迟 {delay:.1f}s)...", flush=True)
-            time.sleep(delay)
-
-        payload, status = http_get_json(url, timeout=20 if attempt > 1 else 15)
-        if payload is None and status == -1:
-            pass
-        elif status == 200 and isinstance(payload, dict) and "stargazers_count" in payload:
-            return payload, "success"
-        elif status in (301, 302):
-            return payload if isinstance(payload, dict) else {}, "redirected"
-        elif status == 404:
-            return payload if isinstance(payload, dict) else {}, "deleted"
-        elif status == 403:
-            return payload if isinstance(payload, dict) else {}, "api_limit"
-        elif status in (429, 502, 503, 504):
-            print(f"    临时错误 HTTP {status}，准备重试", flush=True)
-        else:
-            if status > 0:
-                print(f"    未知HTTP状态码: {status}", flush=True)
-
-        if attempt < MAX_RETRIES:
-            print(f"  尝试 {attempt}/{MAX_RETRIES} 失败，准备重试...", flush=True)
+    payload, status, _ = http_get_json_with_retries(
+        url,
+        timeout=15,
+        context=f"{owner}/{repo}",
+    )
+    if status == 200 and isinstance(payload, dict) and "stargazers_count" in payload:
+        return payload, "success"
+    if status in (301, 302):
+        return payload if isinstance(payload, dict) else {}, "redirected"
+    if status == 404:
+        return payload if isinstance(payload, dict) else {}, "deleted"
+    if status == 403:
+        return payload if isinstance(payload, dict) else {}, "api_limit"
+    if status > 0:
+        print(f"    未知HTTP状态码: {status}", flush=True)
 
     return None, "network_error"
 
@@ -293,7 +392,11 @@ def parse_metadata_text(metadata_text: str) -> Dict[str, Any]:
 def extract_metadata_fields(owner: str, repo: str) -> Dict[str, Any]:
     for metadata_file in ("metadata.yml", "metadata.yaml"):
         url = f"https://api.github.com/repos/{owner}/{repo}/contents/{metadata_file}"
-        payload, status = http_get_json(url, timeout=10)
+        payload, status, _ = http_get_json_with_retries(
+            url,
+            timeout=10,
+            context=f"{owner}/{repo}/{metadata_file}",
+        )
         if status != 200 or not isinstance(payload, dict):
             continue
         content = payload.get("content")
@@ -316,7 +419,11 @@ def extract_version(owner: str, repo: str) -> str:
 
 def extract_logo(owner: str, repo: str, default_branch: str) -> str:
     url = f"https://api.github.com/repos/{owner}/{repo}/contents/logo.png"
-    payload, status = http_get_json(url, timeout=10)
+    payload, status, _ = http_get_json_with_retries(
+        url,
+        timeout=10,
+        context=f"{owner}/{repo}/logo.png",
+    )
     if status == 200 and isinstance(payload, dict) and payload.get("name") == "logo.png":
         return f"https://raw.githubusercontent.com/{owner}/{repo}/{default_branch}/logo.png"
     return ""

--- a/tests/test_transform_plugin_data.py
+++ b/tests/test_transform_plugin_data.py
@@ -50,6 +50,51 @@ class MetadataParsingTests(unittest.TestCase):
         self.assertEqual(block_metadata["support_platforms"], ["aiocqhttp", "qq"])
 
 
+class GitHubRequestTests(unittest.TestCase):
+    def test_select_github_token_round_robins_tokens(self):
+        module = load_transform_module()
+        module.GITHUB_TOKENS = ["token-a", "token-b"]
+        module._TOKEN_INDEX = 0
+
+        self.assertEqual(module.select_github_token(), "token-a")
+        self.assertEqual(module.select_github_token(), "token-b")
+        self.assertEqual(module.select_github_token(), "token-a")
+
+    def test_calculate_retry_delay_uses_rate_limit_reset(self):
+        module = load_transform_module()
+        original_time = module.time.time
+        original_cap = module.RATE_LIMIT_WAIT_CAP
+        original_padding = module.RATE_LIMIT_WAIT_PADDING
+        try:
+            module.time.time = lambda: 100.0
+            module.RATE_LIMIT_WAIT_CAP = 900
+            module.RATE_LIMIT_WAIT_PADDING = 5
+
+            delay = module.calculate_retry_delay(
+                1,
+                403,
+                {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "130"},
+            )
+        finally:
+            module.time.time = original_time
+            module.RATE_LIMIT_WAIT_CAP = original_cap
+            module.RATE_LIMIT_WAIT_PADDING = original_padding
+
+        self.assertEqual(delay, 35)
+
+    def test_calculate_retry_delay_immediately_tries_next_token(self):
+        module = load_transform_module()
+        module.GITHUB_TOKENS = ["token-a", "token-b"]
+
+        delay = module.calculate_retry_delay(
+            1,
+            403,
+            {"X-RateLimit-Remaining": "0", "X-RateLimit-Reset": "130"},
+        )
+
+        self.assertEqual(delay, 0)
+
+
 class TransformPluginDataTests(unittest.TestCase):
     def test_transform_plugin_data_includes_metadata_fields_from_repo_info(self):
         module = load_transform_module()


### PR DESCRIPTION
## Summary
- add PAT_TOKEN_2 to the plugin cache transform workflow
- round-robin GitHub API requests across configured PAT tokens
- retry transient API failures and wait on rate-limit reset headers before falling back to cached metadata

## Tests
- python3 -m unittest tests.test_transform_plugin_data tests.test_detect_changed_plugins tests.test_validate_plugins
- python3 -m py_compile scripts/transform_plugin_data/run.py
- git diff --check

## Summary by Sourcery

Balance GitHub API usage and improve resilience of the plugin cache transform job when fetching repository metadata.

New Features:
- Support configuring multiple GitHub PAT tokens for plugin data transformation and distribute requests across them.
- Introduce configurable rate-limit wait padding and cap for GitHub API retries.

Bug Fixes:
- Ensure transient GitHub API failures and rate-limit responses are retried before falling back to cached plugin metadata, reducing stale data usage.

Enhancements:
- Refactor GitHub JSON fetch logic into reusable retryable helpers with rate-limit awareness and structured logging of retry attempts.
- Extend tests to cover token round-robin selection and rate-limit-based retry delay calculation in the transform script.

CI:
- Update the transform plugin data GitHub Actions workflow to pass a second PAT token secret to the script environment.