### PR TITLE
fix: support additional plugin cache tokens

### DIFF
--- a/.github/workflows/transform-plugin-data.yml
+++ b/.github/workflows/transform-plugin-data.yml
@@ -26,3 +26,4 @@ jobs:
       env:
         PAT_TOKEN: ${{ secrets.PAT_TOKEN }}
         PAT_TOKEN_2: ${{ secrets.PAT_TOKEN_2 }}
+        PAT_TOKEN_3: ${{ secrets.PAT_TOKEN_3 }}

--- a/scripts/transform_plugin_data/run.py
+++ b/scripts/transform_plugin_data/run.py
@@ -38,7 +38,18 @@ _TOKEN_AVAILABLE_AT: Dict[str, float] = {}
 
 def load_github_tokens() -> list[str]:
     tokens: list[str] = []
-    for env_name in ("PAT_TOKEN", "PAT_TOKEN_2"):
+    token_env_names = ["PAT_TOKEN"]
+    numbered_token_env_names = []
+    for env_name in os.environ:
+        match = re.fullmatch(r"PAT_TOKEN_(\d+)", env_name)
+        if match:
+            numbered_token_env_names.append((int(match.group(1)), env_name))
+
+    token_env_names.extend(
+        env_name for _, env_name in sorted(numbered_token_env_names)
+    )
+
+    for env_name in token_env_names:
         token = os.getenv(env_name, "").strip()
         if token and token not in tokens:
             tokens.append(token)

--- a/tests/test_transform_plugin_data.py
+++ b/tests/test_transform_plugin_data.py
@@ -3,6 +3,7 @@ import os
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -51,6 +52,20 @@ class MetadataParsingTests(unittest.TestCase):
 
 
 class GitHubRequestTests(unittest.TestCase):
+    def test_load_github_tokens_includes_numbered_tokens_in_order(self):
+        with mock.patch.dict(
+            os.environ,
+            {
+                "PAT_TOKEN": "token-a",
+                "PAT_TOKEN_3": "token-c",
+                "PAT_TOKEN_2": "token-b",
+            },
+            clear=True,
+        ):
+            module = load_transform_module()
+
+        self.assertEqual(module.GITHUB_TOKENS, ["token-a", "token-b", "token-c"])
+
     def test_select_github_token_round_robins_tokens(self):
         module = load_transform_module()
         module.GITHUB_TOKENS = ["token-a", "token-b"]


### PR DESCRIPTION
## Summary
- pass PAT_TOKEN_3 into the plugin cache transform workflow
- load PAT_TOKEN plus numbered PAT_TOKEN_N variables in numeric order
- keep token de-duplication so repeated secret values are only used once

## Tests
- python3 -m unittest tests.test_transform_plugin_data tests.test_detect_changed_plugins tests.test_validate_plugins
- python3 -m unittest tests.test_transform_plugin_data
- python3 -m py_compile scripts/transform_plugin_data/run.py
- git diff --check

## Summary by Sourcery

Extend GitHub plugin cache token handling to support multiple numbered PAT tokens while preserving deterministic ordering and de-duplication.

New Features:
- Load all PAT_TOKEN_N environment variables in numeric order in addition to the base PAT_TOKEN when building the GitHub token list.

Enhancements:
- Update the transform-plugin-data workflow to pass a third PAT token secret into the environment.
- Refine GitHub token loading logic to derive the token env var list dynamically from the environment instead of a fixed set.

Tests:
- Add a unit test to verify numbered PAT_TOKEN_N variables are loaded in numeric order into GITHUB_TOKENS.