### PR TITLE
fix: 统一 notion-bridge 版本号格式，移除 plugins.json 中多余的 v 前缀

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -230,7 +230,7 @@
     "display_name": "Notion Bridge",
     "desc": "桥接 Notion 与 AstrBot 的双向文档管理工具。支持递归读取、关键词搜索、知识库同步、LLM 查询，以及完整的文档增删改查（页面/块/数据库/用户/评论）。内置 Notion API 3 req/s 速率限制器，可靠管理大量文档。",
     "short_desc": "双向控制 Notion：读取、写入、搜索、管理一站式",
-    "version": "v2.0.1",
+    "version": "2.0.1",
     "author": "Masumeiki",
     "repo": "https://github.com/Masumeiki/astrbot_plugin_notion_bridge",
     "tags": [


### PR DESCRIPTION
## 修改内容

修复 PR #1287 中 Gemini Code Assist bot 指出的版本号格式不一致问题。

**plugins.json** 中 notion-bridge 的版本号从 `v2.0.1` 改为 `2.0.1`，与 `plugin_cache_original.json` 中的格式保持一致。

## 原因

PR #1287 合并后，`plugins.json` 中 notion-bridge 的版本号为 `v2.0.1`（带 v 前缀），而 `plugin_cache_original.json` 中同一插件的版本号为 `2.0.1`（不带 v 前缀）。两处格式不一致，可能导致版本比对或更新检测逻辑异常。在 `plugins.json` 中，其他所有带版本号的插件也均不使用 v 前缀。

## Summary by Sourcery

Bug Fixes:
- Align the notion-bridge version in plugins.json with plugin_cache_original.json by removing the redundant 'v' prefix to avoid potential version comparison issues.