### PR TITLE
添加插件: Nexus_brain — AstrBot 桌面伴侣

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -12689,12 +12689,19 @@
     "category": "utilities"
   }
 ,
-    "astrbot-plugin-nexus-brain": {
-        "display_name": "Nexus_brain — AstrBot 桌面伴侣",
-        "desc": "集中式多平台 AI 大脑 + 悬浮窗桌宠。统一 QQ/微信/飞书/Web Chat 的对话记忆与人格，三层安全网记忆系统，即插即用。",
-        "author": "鹓雏",
-        "repo": "https://github.com/yuanchu114514-spec/nexus-brain",
-        "tags": ["AI伴侣", "桌面宠物", "长期记忆", "多平台", "悬浮窗"],
-        "social_link": "https://space.bilibili.com/621041105"
-    }
+  "astrbot-plugin-nexus-brain": {
+    "display_name": "Nexus_brain — AstrBot 桌面伴侣",
+    "desc": "集中式多平台 AI 大脑 + 悬浮窗桌宠。统一 QQ/微信/飞书/Web Chat 的对话记忆与人格，三层安全网记忆系统，即插即用。",
+    "author": "鹓雏",
+    "repo": "https://github.com/yuanchu114514-spec/nexus-brain",
+    "tags": [
+      "AI伴侣",
+      "桌面宠物",
+      "长期记忆",
+      "多平台",
+      "悬浮窗"
+    ],
+    "social_link": "https://space.bilibili.com/621041105",
+    "category": "entertainment"
+  }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -12688,4 +12688,13 @@
     "repo": "https://github.com/zgojin/astrbot_plugin_thinkTags",
     "category": "utilities"
   }
+,
+    "astrbot-plugin-nexus-brain": {
+        "display_name": "Nexus_brain — AstrBot 桌面伴侣",
+        "desc": "集中式多平台 AI 大脑 + 纯白四芒星悬浮窗桌宠。统一 QQ/微信/飞书/Web Chat 的对话记忆与人格，三层安全网记忆系统，即插即用。",
+        "author": "鹓雏",
+        "repo": "https://github.com/yuanchu114514-spec/nexus-brain",
+        "tags": ["AI伴侣", "桌面宠物", "长期记忆", "多平台", "悬浮窗"],
+        "social_link": "https://space.bilibili.com/621041105"
+    }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -12691,7 +12691,7 @@
 ,
     "astrbot-plugin-nexus-brain": {
         "display_name": "Nexus_brain — AstrBot 桌面伴侣",
-        "desc": "集中式多平台 AI 大脑 + 纯白四芒星悬浮窗桌宠。统一 QQ/微信/飞书/Web Chat 的对话记忆与人格，三层安全网记忆系统，即插即用。",
+        "desc": "集中式多平台 AI 大脑 + 悬浮窗桌宠。统一 QQ/微信/飞书/Web Chat 的对话记忆与人格，三层安全网记忆系统，即插即用。",
         "author": "鹓雏",
         "repo": "https://github.com/yuanchu114514-spec/nexus-brain",
         "tags": ["AI伴侣", "桌面宠物", "长期记忆", "多平台", "悬浮窗"],


### PR DESCRIPTION
## 插件信息

- **名称**: Nexus_brain
- **描述**: 集中式多平台 AI 大脑 
- **作者**: 鹓雏
- **仓库**: https://github.com/yuanchu114514-spec/nexus-brain
- **B站**: https://space.bilibili.com/621041105

## 功能

- 统一 QQ/微信/飞书/Web Chat 共享对话记忆与人格
- 三层安全网记忆系统（增量检查点 → LLM 深度提取 → 紧急保存）
- 56×56 纯白四芒星悬浮窗（PyQt5，零外部图片资源）
- 个性化设置联动记忆文件
- 心跳检测 + 指数退避自动重连
- MIT 开源，AI 辅助开发

封面图: https://raw.githubusercontent.com/yuanchu114514-spec/nexus-brain/master/cover.jpg

## Summary by Sourcery

New Features:
- Register the Nexus_brain multi-platform AI brain and desktop floating window companion plugin in plugins.json so it can be discovered and used by AstrBot users.