### PR TITLE
docs: 更新 PalWorldTerminal 插件市场描述

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -23,7 +23,7 @@
   },
   "astrbot-plugin-palworld": {
     "display_name": "PalWorldTerminal · 帕鲁世界终端",
-    "desc": "监测 Palworld 专用服务器, 提供状态查询、日报与玩家档案。基于官方 REST API。",
+    "desc": "在 AstrBot 中统一管理 Palworld 单服/多服，让群友通过状态、日报、事件与排行参与服内日常；提供可视化设置、分组/逐命令权限，以及默认关闭、仅管理员可用的服务器管控。基于官方 REST API。",
     "author": "SolitudeRA",
     "repo": "https://github.com/SolitudeRA/astrbot_plugin_palworld",
     "tags": [


### PR DESCRIPTION
## 变更

更新 `astrbot-plugin-palworld` 的插件市场描述。

## 原因

现有市场描述仍停留在早期监测能力，未覆盖 v1.0.0 已提供的单服/多服管理、群聊状态/日报/事件/排行、可视化设置、分组/逐命令权限，以及默认关闭且仅管理员可用的服务器管控。

## 影响

插件市场能够更准确地呈现 PalWorldTerminal v1.0.0 的能力。本次不修改插件代码、版本、显示名称、标签或其他插件记录。

## Summary by Sourcery

Documentation:
- Refresh the astrbot-plugin-palworld marketplace description to cover current single/multi-server management, chat status/reporting/features, visual configuration, and permission controls.