### PR TITLE
feat: 添加 Telegraph 长文本插件

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -13248,7 +13248,7 @@
   },
   "astrbot_plugin_telegraph_longtext": {
     "display_name": "Telegraph 长文本",
-    "desc": "自动将超过 1000 字的 AstrBot 回复发布为 Telegraph 页面并发送链接，支持 WebUI 阈值配置、自动分页、常见 Markdown 块、异步重试与失败保留原文。",
+    "desc": "自动将超过 800 字的 AstrBot 回复发布为 Telegraph 页面并发送链接，支持 WebUI 阈值配置、自动分页、常见 Markdown 块、异步重试与失败保留原文。",
     "author": "fzf404",
     "repo": "https://github.com/fzf404/astrbot_plugin_telegraph_longtext",
     "tags": [

--- a/plugins.json
+++ b/plugins.json
@@ -13245,5 +13245,19 @@
     "desc": "过滤消息段中的think",
     "repo": "https://github.com/zgojin/astrbot_plugin_thinkTags",
     "category": "utilities"
+  },
+  "astrbot_plugin_telegraph_longtext": {
+    "display_name": "Telegraph 长文本",
+    "desc": "自动将超过 200 字的 AstrBot 回复发布为 Telegraph 页面并发送链接，支持 WebUI 阈值配置、自动分页、常见 Markdown 块、异步重试与失败保留原文。",
+    "author": "fzf404",
+    "repo": "https://github.com/fzf404/astrbot_plugin_telegraph_longtext",
+    "tags": [
+      "telegram",
+      "telegraph",
+      "长文本",
+      "工具"
+    ],
+    "social_link": "https://github.com/fzf404",
+    "category": "utilities"
   }
 }

--- a/plugins.json
+++ b/plugins.json
@@ -13248,7 +13248,7 @@
   },
   "astrbot_plugin_telegraph_longtext": {
     "display_name": "Telegraph 长文本",
-    "desc": "自动将超过 200 字的 AstrBot 回复发布为 Telegraph 页面并发送链接，支持 WebUI 阈值配置、自动分页、常见 Markdown 块、异步重试与失败保留原文。",
+    "desc": "自动将超过 1000 字的 AstrBot 回复发布为 Telegraph 页面并发送链接，支持 WebUI 阈值配置、自动分页、常见 Markdown 块、异步重试与失败保留原文。",
     "author": "fzf404",
     "repo": "https://github.com/fzf404/astrbot_plugin_telegraph_longtext",
     "tags": [


### PR DESCRIPTION
## 插件信息

- **名称**: Telegraph 长文本
- **仓库**: https://github.com/fzf404/astrbot_plugin_telegraph_longtext
- **版本**: v1.1.1
- **分类**: utilities

## 功能

- 将超过 200 字的 AstrBot 回复自动发布为 Telegraph 页面并发送链接
- 支持 WebUI 自定义阈值、自动分页和常见 Markdown 块
- 支持异步重试，发布失败时保留原始回复
- 当前支持 Telegram，兼容 AstrBot >=4.26.7,<5

## 验证

- `plugins.json` JSON 格式校验通过
- 官方仓库 73 个单元测试通过
- 插件 Ruff 格式与代码检查通过
- 插件单元测试通过，并已在 AstrBot v4.26.7 实际加载运行

Closes #2028

## Summary by Sourcery

Add a Telegraph long-text plugin integration to AstrBot, enabling automatic publishing of long replies as Telegraph pages with configurable thresholds and pagination for Telegram users.

New Features:
- Introduce a Telegraph long-text plugin that converts long AstrBot replies into Telegraph pages and returns the page link.
- Allow WebUI configuration of length thresholds, automatic pagination, and support for common Markdown blocks in published content.
- Provide asynchronous retry handling for Telegraph publishing while preserving the original reply on failures.
- Declare compatibility of the plugin with AstrBot versions >=4.26.7 and <5.

Tests:
- Validate the new plugin entry in plugins.json, ensuring JSON format correctness and passing the plugin’s unit tests and style checks.