### PR TITLE
feat: 添加 astrbot_plugin_vpn_proxy（vpn代理插件）

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -13251,5 +13251,17 @@
     "desc": "过滤消息段中的think",
     "repo": "https://github.com/zgojin/astrbot_plugin_thinkTags",
     "category": "utilities"
+  },
+  "astrbot_plugin_vpn_proxy": {
+    "display_name": "🌐 vpn代理插件",
+    "desc": "VPN节点代理管理插件：支持VLESS/SS/VMess/Trojan/SOCKS5/HTTP/WireGuard节点与订阅管理，节点延迟测试，为AstrBot API请求提供VPN加速。",
+    "author": "铃兰",
+    "repo": "https://github.com/pucha201/astrbot_plugin_vpn_proxy",
+    "tags": [
+      "vpn",
+      "代理"
+    ],
+    "social_link": "https://github.com/pucha201",
+    "category": "utilities"
   }
 }


### PR DESCRIPTION
## 新增插件：astrbot_plugin_vpn_proxy（🌐 vpn代理插件）

VPN 节点代理管理插件，为 AstrBot 模型 API 请求提供 VPN 加速。

### 功能
- 支持 **7 种协议**：VLESS / SS / VMess / Trojan / SOCKS5 / HTTP / WireGuard
- 节点与订阅管理（URL 解析、面板模板添加）
- **节点延迟测试**（管理界面一键测速）
- 独立管理界面（深色 Web UI）
- 输出统一 HTTP 代理地址 `http://127.0.0.1:10809`，按模型提供方分流（谁填谁走 VPN）

### 元数据
- 仓库: https://github.com/pucha201/astrbot_plugin_vpn_proxy
- 版本: v2.2.0
- plugin_id: 铃兰/astrbot_plugin_vpn_proxy

已按 2026-06-27 市场 JSON 规范添加记录，字段齐全。

## Summary by Sourcery

New Features:
- Add metadata entry for the astrbot_plugin_vpn_proxy VPN proxy plugin supporting multiple VPN protocols and node management.